### PR TITLE
Fixed iOS not handling cookies properly

### DIFF
--- a/lib/webviewbridge.js
+++ b/lib/webviewbridge.js
@@ -405,6 +405,9 @@ const WebViewBridge = new extend(EventEmitter)(function(_super, options) {
 
 });
 
+function parseCookie(cookie) {
+    return cookie.split(";").map(comp => "document.cookie='" + comp + "'").join(";") + ";";
+}
 
 function customNavigate(options) {
     const webView = this.webView;
@@ -414,6 +417,11 @@ function customNavigate(options) {
 
 
     if (System.OS === "iOS") {
+        if (cookie) {
+            webView.nativeObject.onStartDocumentHandler = _ => {
+                this.evaluateJS(parseCookie(cookie));
+            };
+        }
         var MutableRequest = SF.requireClass("NSMutableURLRequest");
         var NSURL = SF.requireClass("NSURL");
 

--- a/lib/webviewbridge.js
+++ b/lib/webviewbridge.js
@@ -406,7 +406,7 @@ const WebViewBridge = new extend(EventEmitter)(function(_super, options) {
 });
 
 function parseCookie(cookie) {
-    return cookie.split(";").map(comp => "document.cookie='" + comp + "'").join(";") + ";";
+    return cookie.split(";").map(comp => `document.cookie= '${comp}';`).join(";");
 }
 
 function customNavigate(options) {
@@ -418,7 +418,7 @@ function customNavigate(options) {
 
     if (System.OS === "iOS") {
         if (cookie) {
-            webView.nativeObject.onStartDocumentHandler = _ => {
+            webView.nativeObject.onStartDocumentHandler = () => {
                 this.evaluateJS(parseCookie(cookie));
             };
         }


### PR DESCRIPTION
Added a handler event to hold cookies after navigation on iOS and a function to parse cookies.