### PR TITLE
changed ripple duration to 100 MS and made it default

### DIFF
--- a/doc/touch.md
+++ b/doc/touch.md
@@ -27,7 +27,7 @@ This replaces existing touch events
 **Params**: <code>function</code> [options.endTouchEffect=defaultClearPressEffect] - Function called when press effect ends; it is used to revert the effects in startTouchEffect. It should be used together with startTouchEffect. If not provided default effect reversing will be applied  
 **Params**: <code>boolean</code> [options.consumeTouch=false] - If this option is set to true, touch events won't be passed through views. If not provided, default value is undefined  
 **Params**: <code>boolean</code> [options.disableRippleEffect=false] - Enables the ripple effect on given target. This option specfic to Android  
-**Params**: <code>number</code> [options.rippleDuration=0] - Ripple effect requires duration before performing given event. This option specfic to Android  
+**Params**: <code>number</code> [options.rippleDuration=100] - Ripple effect requires duration before performing given event. This option specfic to Android  
 **Params**: <code>boolean</code> [options.rippleUseBackground=false] - if this options is set to true, ripple effect added on background of the given target. If target contains child components, draw ripple effect below them. This option specfic to Android.  
 **Params**: <code>UI.Color</code> [options.rippleColor=Color.create("#d8d8d8")] - Sets the color to ripple effect. This option specfic to Android  
 **Params**: <code>UI.Color</code> [options.fadeColor=Color.create("#d8d8d8")] - Sets the color to fade effect. This option specfic to iOS  

--- a/lib/touch.js
+++ b/lib/touch.js
@@ -18,7 +18,7 @@ const FPS = 60;
 const TICKS = 1000 / FPS;
 const ELEVATION_CHANGE = 14;
 const ELEVATION_CHANGE_PER_FRAME = ELEVATION_CHANGE / (ANIMATION_DURATION / TICKS);
-const DURATION = 400;
+const DURATION = 100;
 const iOS_FADE_DURATION = 0.2;
 const iOS_FADE_MAXOPACITY = 0.3;
 
@@ -41,7 +41,7 @@ Object.assign(exports, {
  * @params {function} [options.endTouchEffect=defaultClearPressEffect] - Function called when press effect ends; it is used to revert the effects in startTouchEffect. It should be used together with startTouchEffect. If not provided default effect reversing will be applied
  * @params {boolean} [options.consumeTouch=false] - If this option is set to true, touch events won't be passed through views. If not provided, default value is undefined
  * @params {boolean} [options.disableRippleEffect=false] - Enables the ripple effect on given target. This option specfic to Android
- * @params {number} [options.rippleDuration=0] - Ripple effect requires duration before performing given event. This option specfic to Android
+ * @params {number} [options.rippleDuration=100] - Ripple effect requires duration before performing given event. This option specfic to Android
  * @params {boolean} [options.rippleUseBackground=false] - if this options is set to true, ripple effect added on background of the given target. If target contains child components, draw ripple effect below them. This option specfic to Android.
  * @params {UI.Color} [options.rippleColor=Color.create("#d8d8d8")] - Sets the color to ripple effect. This option specfic to Android
  * @params {UI.Color} [options.fadeColor=Color.create("#d8d8d8")] - Sets the color to fade effect. This option specfic to iOS
@@ -61,7 +61,7 @@ function addPressEvent(target, event, options) {
     options.startTouchEffect = options.startTouchEffect || defaultAddPressEffect.bind(target);
     options.endTouchEffect = options.endTouchEffect || defaultClearPressEffect.bind(target);
     options.consumeTouch = options.consumeTouch || false;
-    options.rippleDuration = options.rippleDuration || 0;
+    options.rippleDuration = options.rippleDuration || DURATION;
     options.rippleUseBackground = options.rippleUseBackground || false;
     options.rippleColor = options.rippleColor || Color.create("#d8d8d8");
     options.disableRippleEffect = options.disableRippleEffect || false;


### PR DESCRIPTION
I think 400 ms duration is not a good idea, makes the interactions very sluggish, also 0 second delay ( no ripple effect even when you set enableRippleEffect property to true )by default is not good idea either. Updated docs relatively.