### PR TITLE
updated to 5.5.5 and fixed a bottomtabbar router issue

### DIFF
--- a/lib/router/goBack.js
+++ b/lib/router/goBack.js
@@ -13,6 +13,7 @@
 const Application = require("sf-core/application");
 const active = require("./active");
 const StackRouter = require("@smartface/router/src/native/NativeStackRouter");
+const BottomTabBarRouter = require("@smartface/router/src/native/BottomTabBarRouter");
 const buildExtender = require("./buildExtender");
 
 Application.android.onBackButtonPressed = () => {
@@ -27,6 +28,9 @@ const defaultGoBack = () => {
     if (shouldExit) {
         Application.exit();
         return;
+    }
+    if(router instanceof BottomTabBarRouter){
+        return; // TODO: Find a way to go between BottomTabBarRouters
     }
     if (router instanceof StackRouter) {
         let historyAsArray = router.getHistoryasArray();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-extension-utils",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "Utils Extension for Smartface Native Framework",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Currently BottomTabBar gives some unexpected errors. Disable it for the time being.