### PR TITLE
feat(polyfill-padStart): Added a polyfill for String.prototype.padStart

### DIFF
--- a/lib/base/polyfill.js
+++ b/lib/base/polyfill.js
@@ -10,3 +10,21 @@ Promise.prototype.finally = Promise.prototype.finally || function finallyPolyfil
         });
     });
 };
+
+// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
+if (!String.prototype.padStart) {
+    String.prototype.padStart = function padStart(targetLength, padString) {
+        targetLength = targetLength >> 0; //truncate if number, or convert non-number to 0;
+        padString = String(typeof padString !== 'undefined' ? padString : ' ');
+        if (this.length >= targetLength) {
+            return String(this);
+        } else {
+            targetLength = targetLength - this.length;
+            if (targetLength > padString.length) {
+                padString += padString.repeat(targetLength / padString.length); //append to original to ensure we are longer than needed
+            }
+            return padString.slice(0, targetLength) + String(this);
+        }
+    };
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart

Since String.padStart is supported on Node > 8.0.0, it won't be supported for Smartface platform on Android.