### PR TITLE
Update back-close.js

### DIFF
--- a/lib/router/back-close.js
+++ b/lib/router/back-close.js
@@ -97,7 +97,7 @@ const backClose = (match, routeData, router, pageInstance, pageProps, route) => 
                         }
                         else {
                             pageInstance.headerBar.setItems([hbi]);
-                            pageInstance.headerBar.leftItemEnabled = true;
+                            pageInstance.headerBar.leftItemEnabled = false;
                         }
                         dismissConfig.retrieveItem &&
                             dismissConfig.retrieveItem(hbi);


### PR DESCRIPTION
On Android, with the following snippet, both back icons and the left title was created on HeaderBar. With this PR, only desired right item will be created. Just like on iOS.

```
backClose.dissmissBuilder = (match, routeData, router, pageInstance, pageProps, route) => {
    return { text: global.lang.cancel, position: "right" };
};
```