### PR TITLE
fix(layoutManager): Fix crash on GridView when using getCombinedStyle

### DIFF
--- a/lib/getCombinedStyle.js
+++ b/lib/getCombinedStyle.js
@@ -29,7 +29,8 @@ const getCombinedStyle = className => {
     let dummyComponent = {
         ios: {},
         android: {},
-        layout: {}
+        layout: {},
+        layoutManager: {}
     };
     componentContextPatch(dummyComponent, guid());
     dummyComponent.dispatch({


### PR DESCRIPTION
DummyComponent doesn't have a layoutManager object inside. So assigning to undefined crashes the application